### PR TITLE
fix: allow cors user api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,4 @@ COPY ./ /app
 
 WORKDIR /app
 EXPOSE 8080
-CMD ["gunicorn", "app:app()", "-c", "gunicorn.conf.conf.py"]
+CMD ["gunicorn", "app:app()", "-c", "gunicorn.conf.py"]

--- a/model/user.py
+++ b/model/user.py
@@ -1,6 +1,6 @@
 from urllib import parse
 from typing import Optional
-from flask import Blueprint, current_app
+from flask import Blueprint, current_app, request
 from mongo import engine
 from mongo.utils import drop_none
 from mongo import *
@@ -12,18 +12,11 @@ __all__ = ['user_api']
 user_api = Blueprint('user_api', __name__)
 
 
-@user_api.before_request
-@identity_verify(0)
-def before_user_api(user):
-    '''
-    We only allow admin to use user API (currently)
-    '''
-    pass
-
-
 @user_api.get('/')
+@identity_verify(0)
 @Request.args('offset', 'count', 'course', 'role')
 def get_user_list(
+    user,
     offset: Optional[str],
     count: Optional[str],
     course: Optional[str],
@@ -61,8 +54,10 @@ def get_user_list(
 
 
 @user_api.post('/')
+@identity_verify(0)
 @Request.json('username: str', 'password: str', 'email: str')
 def add_user(
+    user,
     username: str,
     password: str,
     email: str,
@@ -86,9 +81,8 @@ def add_user(
     return HTTPResponse()
 
 
-# username
 @user_api.patch('/<username>')
-@login_required
+@identity_verify(0)
 @Request.doc('username', 'target_user', User)
 @Request.json('password', 'displayed_name', 'role')
 def update_user(

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -221,3 +221,11 @@ def test_non_admin_cannot_update_user_data(
     assert rv.status_code == 403, rv_json
     # ensure user is not updated
     assert user.reload().to_json() == original_user
+
+
+def test_client_can_make_cors_preflight_request(client):
+    # CORS-preflight requests must never include credentials, so
+    # using a unauthorized client here
+    # see more: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflight_requests_and_credentials
+    rv = client.options('/user')
+    assert rv.status_code == 200


### PR DESCRIPTION
因為原本 user api 是在 `before_request` 中去驗證 client 是否為 admin，然而 CORS preflight request 是不會帶 cookie 的，因此造成要發給 user api 的 request 會失敗。把驗證 admin 的 code 移到各 route 上面的話，就可以讓 flask 改成回覆一個預設的回應了。

https://github.com/pallets/flask/blob/2f67e0fe4aca8a8d6998b3022150f1e6d6738214/src/flask/app.py#L1475-L1481