### PR TITLE
(CI): add CI to generate coverage report and badge

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -23,7 +23,7 @@ jobs:
         run: poetry run yapf -- --recursive --parallel --diff .
       - name: Unit test
         run: |
-          poetry run pytest -- --cov=./ --cov-report=html:report/coverage --cov-config=.coveragerc
+          poetry run pytest -- --cov=./ --cov-report=html:report --cov-config=.coveragerc
           poetry run coverage report
       # coverage-report
       - name: Coverage Badge

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -30,6 +30,8 @@ jobs:
         uses: tj-actions/coverage-badge-py@v2
         with:
           output: report/coverage.svg
+      - name: Debug
+        run: ls -al report/
       - name: Publish coverage report to gh-pages branch
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           poetry run pytest -- --cov=./ --cov-report=html:report --cov-config=.coveragerc
           poetry run coverage report
-          ls -al report/
       # coverage-report
       - name: Coverage Badge
         uses: tj-actions/coverage-badge-py@v2

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -22,18 +22,4 @@ jobs:
       - name: Format
         run: poetry run yapf -- --recursive --parallel --diff .
       - name: Unit test
-        run: |
-          poetry run pytest -- --cov=./ --cov-report=html:report --cov-config=.coveragerc
-          poetry run coverage report
-      # coverage-report
-      - name: Coverage Badge
-        uses: tj-actions/coverage-badge-py@v2
-        with:
-          output: report/coverage.svg
-      - name: Remove gitignore
-        run: rm report/.gitignore
-      - name: Publish coverage report to gh-pages branch
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./report
+        run: poetry run pytest -- --cov=./ --cov-config=.coveragerc

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -22,4 +22,16 @@ jobs:
       - name: Format
         run: poetry run yapf -- --recursive --parallel --diff .
       - name: Unit test
-        run: poetry run pytest -- --cov=./ --cov-config=.coveragerc
+        run: |
+          poetry run pytest -- --cov=./ --cov-report=html:report/coverage --cov-config=.coveragerc
+          poetry run coverage report
+      # coverage-report
+      - name: Coverage Badge
+        uses: tj-actions/coverage-badge-py@v2
+        with:
+          output: report/coverage.svg
+      - name: Publish coverage report to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./report

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -25,13 +25,14 @@ jobs:
         run: |
           poetry run pytest -- --cov=./ --cov-report=html:report --cov-config=.coveragerc
           poetry run coverage report
+          ls -al report/
       # coverage-report
       - name: Coverage Badge
         uses: tj-actions/coverage-badge-py@v2
         with:
           output: report/coverage.svg
-      - name: Debug
-        run: ls -al report/
+      - name: Remove gitignore
+        run: rm report/.gitignore
       - name: Publish coverage report to gh-pages branch
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/generate-coverage-badge.yml
+++ b/.github/workflows/generate-coverage-badge.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Generate Coverage Badge
 
 on:
   push:

--- a/.github/workflows/generate-coverage-badge.yml
+++ b/.github/workflows/generate-coverage-badge.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Poetry
+        run: pipx install poetry
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+          cache: "poetry"
+      - name: Install Dependency
+        run: poetry install
+      - name: Format
+        run: poetry run yapf -- --recursive --parallel --diff .
+      - name: Unit test
+        run: |
+          poetry run pytest -- --cov=./ --cov-report=html:report/coverage --cov-config=.coveragerc
+          poetry run coverage report
+      # coverage-report
+      - name: Coverage Badge
+        uses: tj-actions/coverage-badge-py@v2
+        with:
+          output: report/coverage.svg
+      - name: Publish coverage report to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./report

--- a/.github/workflows/generate-coverage-badge.yml
+++ b/.github/workflows/generate-coverage-badge.yml
@@ -23,13 +23,15 @@ jobs:
         run: poetry run yapf -- --recursive --parallel --diff .
       - name: Unit test
         run: |
-          poetry run pytest -- --cov=./ --cov-report=html:report/coverage --cov-config=.coveragerc
+          poetry run pytest -- --cov=./ --cov-report=html:report --cov-config=.coveragerc
           poetry run coverage report
       # coverage-report
       - name: Coverage Badge
         uses: tj-actions/coverage-badge-py@v2
         with:
           output: report/coverage.svg
+      - name: Remove gitignore
+        run: rm report/.gitignore
       - name: Publish coverage report to gh-pages branch
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NOJ Backend
 
+[![Coverage Badge](https://normal-oj.github.io/Back-End/coverage.svg)](https://normal-oj.github.io/Back-End/index.html)
+
 This respository uses [Poetry](https://python-poetry.org/) to manage Python dependencies.
 
 You need to have a Python interpreter higher than 3.8


### PR DESCRIPTION
generate the coverage.svg without 3rd party support
in README.md link the coverage.svg to actual html coverage report

the coverage html report and the coverage.svg will be pushed to gh-pages branch
you can see at [https://github.com/Normal-OJ/Back-End/tree/feat/coverage-badge](https://github.com/Normal-OJ/Back-End/tree/feat/coverage-badge)