### PR TITLE
feat: add pull-based runner API (GitHub Actions runner style)

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ def app():
         (copycat_api, '/copycat'),
         (health_api, '/health'),
         (user_api, '/user'),
+        (runner_api, '/runner'),
     ]
     for api, prefix in api2prefix:
         app.register_blueprint(api, url_prefix=prefix)

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -11,6 +11,7 @@ from . import post
 from . import copycat
 from . import health
 from . import user
+from . import runner
 
 from .auth import *
 from .profile import *
@@ -25,6 +26,7 @@ from .post import *
 from .copycat import *
 from .health import *
 from .user import *
+from .runner import *
 
 __all__ = [
     *auth.__all__,
@@ -40,4 +42,5 @@ __all__ = [
     *copycat.__all__,
     *health.__all__,
     *user.__all__,
+    *runner.__all__,
 ]

--- a/model/runner.py
+++ b/model/runner.py
@@ -1,0 +1,290 @@
+import io
+import secrets
+from flask import Blueprint, request, send_file
+from datetime import datetime, timedelta
+from mongo import *
+from mongo import engine
+from mongo.utils import RedisCache, MinioClient
+from .utils import *
+
+__all__ = ['runner_api']
+runner_api = Blueprint('runner_api', __name__)
+
+# Claim timeout: if a runner doesn't complete within this time,
+# the job becomes available again (like GitHub Actions runner timeout)
+CLAIM_TIMEOUT_SECONDS = 600
+
+
+def _verify_runner_token(req):
+    """Verify the runner token from request headers or params."""
+    token = req.headers.get('X-Runner-Token') or req.args.get('token', '')
+    config = Submission.config()
+    for sb in config.sandbox_instances:
+        if secrets.compare_digest(token, sb.token):
+            return True
+    return False
+
+
+def _get_runner_name(req):
+    """Get runner name from request headers."""
+    return req.headers.get('X-Runner-Name', 'unknown')
+
+
+@runner_api.before_request
+def check_runner_auth():
+    if not _verify_runner_token(request):
+        return HTTPError('invalid runner token', 403)
+
+
+@runner_api.route('/jobs', methods=['GET'])
+def get_pending_jobs():
+    """
+    Runner polls this endpoint to find available jobs.
+    Returns pending submissions that are not claimed or whose claim has expired.
+
+    Similar to GitHub Actions: runner asks "any work for me?"
+    """
+    now = datetime.now()
+    claim_deadline = now - timedelta(seconds=CLAIM_TIMEOUT_SECONDS)
+
+    # Find submissions that are:
+    # 1. status=-1 (judging / ready to be judged)
+    # 2. Not claimed, OR claim has expired
+    # 3. Not handwritten (language != 3)
+    pending = engine.Submission.objects(
+        status=-1,
+        language__ne=3,
+    ).order_by('last_send')
+
+    jobs = []
+    for sub in pending:
+        # Skip if actively claimed by another runner
+        if (sub.claimed_by is not None and sub.claimed_at is not None
+                and sub.claimed_at > claim_deadline):
+            continue
+        # Skip if no code uploaded yet
+        if sub.code_minio_path is None and (sub.code is None
+                                            or sub.code.grid_id is None):
+            continue
+        jobs.append({
+            'submissionId': str(sub.id),
+            'problemId': sub.problem.problem_id,
+            'language': sub.language,
+            'timestamp': sub.timestamp.timestamp(),
+        })
+        # Return at most 10 jobs per poll
+        if len(jobs) >= 10:
+            break
+
+    return HTTPResponse('ok', data={'jobs': jobs})
+
+
+@runner_api.route('/jobs/<submission_id>/claim', methods=['POST'])
+def claim_job(submission_id: str):
+    """
+    Runner claims a job for processing.
+
+    Similar to GitHub Actions: runner picks up a job from the queue.
+    Uses optimistic locking via claimed_at to prevent double-claiming.
+    """
+    try:
+        sub = engine.Submission.objects.get(id=submission_id)
+    except engine.DoesNotExist:
+        return HTTPError('submission not found', 404)
+
+    if sub.status != -1:
+        return HTTPError('submission is not pending', 409)
+
+    now = datetime.now()
+    claim_deadline = now - timedelta(seconds=CLAIM_TIMEOUT_SECONDS)
+
+    # Check if already claimed by an active runner
+    if (sub.claimed_by is not None and sub.claimed_at is not None
+            and sub.claimed_at > claim_deadline):
+        return HTTPError('already claimed by another runner', 409)
+
+    runner_name = _get_runner_name(request)
+
+    # Claim the job
+    sub.update(
+        claimed_by=runner_name,
+        claimed_at=now,
+    )
+
+    # Generate and assign a token for result callback
+    token = Submission.assign_token(submission_id)
+
+    # Build job metadata
+    problem = sub.problem
+    test_case = problem.test_case
+    tasks = []
+    for t in test_case.tasks:
+        tasks.append({
+            'taskScore': t.task_score,
+            'caseCount': t.case_count,
+            'memoryLimit': t.memory_limit,
+            'timeLimit': t.time_limit,
+        })
+
+    return HTTPResponse(
+        'job claimed',
+        data={
+            'submissionId': str(sub.id),
+            'problemId': problem.problem_id,
+            'language': sub.language,
+            'token': token,
+            'meta': {
+                'language': sub.language,
+                'tasks': tasks,
+            },
+        },
+    )
+
+
+@runner_api.route('/jobs/<submission_id>/code', methods=['GET'])
+def get_job_code(submission_id: str):
+    """
+    Runner downloads the source code zip for a claimed job.
+    """
+    try:
+        sub = engine.Submission.objects.get(id=submission_id)
+    except engine.DoesNotExist:
+        return HTTPError('submission not found', 404)
+
+    # Verify this runner has claimed this job
+    runner_name = _get_runner_name(request)
+    if sub.claimed_by != runner_name:
+        return HTTPError('not claimed by this runner', 403)
+
+    # Get code from minio or gridfs
+    if sub.code_minio_path is not None:
+        minio_client = MinioClient()
+        try:
+            resp = minio_client.client.get_object(
+                minio_client.bucket,
+                sub.code_minio_path,
+            )
+            data = resp.read()
+        finally:
+            if 'resp' in locals():
+                resp.close()
+                resp.release_conn()
+    elif sub.code is not None and sub.code.grid_id is not None:
+        data = sub.code.read()
+    else:
+        return HTTPError('code not found', 404)
+
+    return send_file(
+        io.BytesIO(data),
+        mimetype='application/zip',
+        as_attachment=True,
+        download_name=f'{submission_id}.zip',
+    )
+
+
+@runner_api.route('/jobs/<submission_id>/testdata', methods=['GET'])
+def get_job_testdata(submission_id: str):
+    """
+    Runner downloads the testdata zip for a claimed job's problem.
+    """
+    try:
+        sub = engine.Submission.objects.get(id=submission_id)
+    except engine.DoesNotExist:
+        return HTTPError('submission not found', 404)
+
+    runner_name = _get_runner_name(request)
+    if sub.claimed_by != runner_name:
+        return HTTPError('not claimed by this runner', 403)
+
+    problem = sub.problem
+    submission = Submission(submission_id)
+    # Use the existing problem testdata download logic
+    test_case = problem.test_case
+    if test_case.case_zip_minio_path is not None:
+        minio_client = MinioClient()
+        try:
+            resp = minio_client.client.get_object(
+                minio_client.bucket,
+                test_case.case_zip_minio_path,
+            )
+            data = resp.read()
+        finally:
+            if 'resp' in locals():
+                resp.close()
+                resp.release_conn()
+    elif test_case.case_zip is not None and test_case.case_zip.grid_id is not None:
+        data = test_case.case_zip.read()
+    else:
+        return HTTPError('testdata not found', 404)
+
+    return send_file(
+        io.BytesIO(data),
+        mimetype='application/zip',
+        as_attachment=True,
+        download_name=f'testdata-{problem.problem_id}.zip',
+    )
+
+
+@runner_api.route('/jobs/<submission_id>/complete', methods=['PUT'])
+def on_job_complete(submission_id: str):
+    """
+    Runner reports job completion with results.
+    Reuses the existing submission completion logic.
+
+    This is the same as the existing /submission/<id>/complete endpoint,
+    but authenticated via runner token instead of per-submission token.
+    """
+    data = request.json
+    if data is None:
+        return HTTPError('missing JSON body', 400)
+
+    tasks = data.get('tasks')
+    token = data.get('token')
+    if tasks is None or token is None:
+        return HTTPError('missing tasks or token', 400)
+
+    submission = Submission(submission_id)
+    if not submission:
+        return HTTPError('submission not found', 404)
+
+    if not Submission.verify_token(submission.id, token):
+        return HTTPError('invalid submission token', 403)
+
+    try:
+        submission.process_result(tasks)
+    except (engine.ValidationError, KeyError) as e:
+        return HTTPError(
+            f'invalid data!\n{type(e).__name__}: {e}',
+            400,
+        )
+
+    # Clear claim fields after successful completion
+    submission.update(claimed_by=None, claimed_at=None)
+
+    return HTTPResponse(f'{submission} result received.')
+
+
+@runner_api.route('/heartbeat', methods=['POST'])
+def runner_heartbeat():
+    """
+    Runner sends periodic heartbeat to extend claim timeout.
+
+    Similar to GitHub Actions: runner reports it's still alive.
+    """
+    data = request.json or {}
+    submission_id = data.get('submissionId')
+    if submission_id is None:
+        return HTTPResponse('ok')
+
+    try:
+        sub = engine.Submission.objects.get(id=submission_id)
+    except engine.DoesNotExist:
+        return HTTPError('submission not found', 404)
+
+    runner_name = _get_runner_name(request)
+    if sub.claimed_by != runner_name:
+        return HTTPError('not claimed by this runner', 403)
+
+    # Extend the claim
+    sub.update(claimed_at=datetime.now())
+    return HTTPResponse('heartbeat received')

--- a/model/runner.py
+++ b/model/runner.py
@@ -17,7 +17,7 @@ CLAIM_TIMEOUT_SECONDS = 600
 
 def _verify_runner_token(req):
     """Verify the runner token from request headers or params."""
-    token = req.headers.get('X-Runner-Token') or req.args.get('token', '')
+    token = req.headers.get('X-Runner-Token', '')
     config = Submission.config()
     for sb in config.sandbox_instances:
         if secrets.compare_digest(token, sb.token):
@@ -44,6 +44,7 @@ def get_pending_jobs():
 
     Similar to GitHub Actions: runner asks "any work for me?"
     """
+    from mongoengine.queryset.visitor import Q
     now = datetime.now()
     claim_deadline = now - timedelta(seconds=CLAIM_TIMEOUT_SECONDS)
 
@@ -52,16 +53,12 @@ def get_pending_jobs():
     # 2. Not claimed, OR claim has expired
     # 3. Not handwritten (language != 3)
     pending = engine.Submission.objects(
-        status=-1,
-        language__ne=3,
-    ).order_by('last_send')
+        Q(status=-1) & Q(language__ne=3)
+        & (Q(claimed_by=None) | Q(claimed_at=None)
+           | Q(claimed_at__lte=claim_deadline)), ).order_by('last_send')
 
     jobs = []
     for sub in pending:
-        # Skip if actively claimed by another runner
-        if (sub.claimed_by is not None and sub.claimed_at is not None
-                and sub.claimed_at > claim_deadline):
-            continue
         # Skip if no code uploaded yet
         if sub.code_minio_path is None and (sub.code is None
                                             or sub.code.grid_id is None):
@@ -87,29 +84,31 @@ def claim_job(submission_id: str):
     Similar to GitHub Actions: runner picks up a job from the queue.
     Uses optimistic locking via claimed_at to prevent double-claiming.
     """
-    try:
-        sub = engine.Submission.objects.get(id=submission_id)
-    except engine.DoesNotExist:
-        return HTTPError('submission not found', 404)
-
-    if sub.status != -1:
-        return HTTPError('submission is not pending', 409)
-
+    from mongoengine.queryset.visitor import Q
     now = datetime.now()
     claim_deadline = now - timedelta(seconds=CLAIM_TIMEOUT_SECONDS)
-
-    # Check if already claimed by an active runner
-    if (sub.claimed_by is not None and sub.claimed_at is not None
-            and sub.claimed_at > claim_deadline):
-        return HTTPError('already claimed by another runner', 409)
-
     runner_name = _get_runner_name(request)
 
-    # Claim the job
-    sub.update(
-        claimed_by=runner_name,
-        claimed_at=now,
-    )
+    # Atomic conditional update to prevent race conditions
+    updated = engine.Submission.objects(
+        Q(id=submission_id) & Q(status=-1)
+        & (Q(claimed_by=None) | Q(claimed_at=None)
+           | Q(claimed_at__lte=claim_deadline)), ).update_one(
+               set__claimed_by=runner_name,
+               set__claimed_at=now,
+           )
+
+    if updated == 0:
+        # Either not found, not pending, or already claimed
+        try:
+            sub = engine.Submission.objects.get(id=submission_id)
+        except engine.DoesNotExist:
+            return HTTPError('submission not found', 404)
+        if sub.status != -1:
+            return HTTPError('submission is not pending', 409)
+        return HTTPError('already claimed by another runner', 409)
+
+    sub = engine.Submission.objects.get(id=submission_id)
 
     # Generate and assign a token for result callback
     token = Submission.assign_token(submission_id)
@@ -197,8 +196,6 @@ def get_job_testdata(submission_id: str):
         return HTTPError('not claimed by this runner', 403)
 
     problem = sub.problem
-    submission = Submission(submission_id)
-    # Use the existing problem testdata download logic
     test_case = problem.test_case
     if test_case.case_zip_minio_path is not None:
         minio_client = MinioClient()
@@ -242,6 +239,16 @@ def on_job_complete(submission_id: str):
     token = data.get('token')
     if tasks is None or token is None:
         return HTTPError('missing tasks or token', 400)
+
+    # Verify the completing runner is the one that claimed this job
+    try:
+        sub = engine.Submission.objects.get(id=submission_id)
+    except engine.DoesNotExist:
+        return HTTPError('submission not found', 404)
+
+    runner_name = _get_runner_name(request)
+    if sub.claimed_by != runner_name:
+        return HTTPError('not claimed by this runner', 403)
 
     submission = Submission(submission_id)
     if not submission:

--- a/mongo/engine.py
+++ b/mongo/engine.py
@@ -372,6 +372,17 @@ class Submission(Document):
     last_send = DateTimeField(db_field='lastSend', default=datetime.now)
     comment = FileField(default=None, null=True)
     ip_addr = StringField(default=None, null=True)
+    # Runner (pull-based) fields
+    claimed_by = StringField(
+        null=True,
+        default=None,
+        db_field='claimedBy',
+    )
+    claimed_at = DateTimeField(
+        null=True,
+        default=None,
+        db_field='claimedAt',
+    )
 
 
 class Message(Document):

--- a/mongo/submission.py
+++ b/mongo/submission.py
@@ -435,8 +435,7 @@ class Submission(MongoBase, engine=engine.Submission):
         # Pull mode: just mark as pending, runners will pick it up
         runner_mode = os.getenv('RUNNER_MODE', 'push')
         if runner_mode == 'pull':
-            self.logger.info(
-                f'{self} queued for runner pickup (pull mode)')
+            self.logger.info(f'{self} queued for runner pickup (pull mode)')
             return True
         # Push mode (original behavior)
         # TODO: Ensure problem is ready to submitted

--- a/mongo/submission.py
+++ b/mongo/submission.py
@@ -423,10 +423,22 @@ class Submission(MongoBase, engine=engine.Submission):
     def send(self) -> bool:
         '''
         send code to sandbox
+
+        Supports two modes:
+        - push (default): actively sends submission to a sandbox instance
+        - pull: marks submission as pending for runners to pick up
+          (set RUNNER_MODE=pull environment variable to enable)
         '''
         if self.handwritten:
             logging.warning(f'try to send a handwritten {self}')
             return False
+        # Pull mode: just mark as pending, runners will pick it up
+        runner_mode = os.getenv('RUNNER_MODE', 'push')
+        if runner_mode == 'pull':
+            self.logger.info(
+                f'{self} queued for runner pickup (pull mode)')
+            return True
+        # Push mode (original behavior)
         # TODO: Ensure problem is ready to submitted
         # if not Problem(self.problem).is_test_case_ready():
         #     raise TestCaseNotFound(self.problem.problem_id)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -25,12 +25,22 @@ def setup_minio():
     )
     proc = subprocess.run(
         [
-            'docker', 'run', '-d',
-            '--name', container_name,
-            '-p', '19000:9000',
-            '-e', 'MINIO_ROOT_USER=minioadmin',
-            '-e', 'MINIO_ROOT_PASSWORD=minioadmin',
-            'minio/minio:latest', 'server', '/data', '--address', ':9000',
+            'docker',
+            'run',
+            '-d',
+            '--name',
+            container_name,
+            '-p',
+            '19000:9000',
+            '-e',
+            'MINIO_ROOT_USER=minioadmin',
+            '-e',
+            'MINIO_ROOT_PASSWORD=minioadmin',
+            'minio/minio:latest',
+            'server',
+            '/data',
+            '--address',
+            ':9000',
         ],
         capture_output=True,
         text=True,
@@ -41,7 +51,8 @@ def setup_minio():
     for _ in range(30):
         try:
             import urllib.request
-            urllib.request.urlopen('http://localhost:19000/minio/health/live', timeout=2)
+            urllib.request.urlopen('http://localhost:19000/minio/health/live',
+                                   timeout=2)
             break
         except Exception:
             _time.sleep(1)
@@ -66,6 +77,7 @@ def setup_minio():
 
     subprocess.run(['docker', 'rm', '-f', container_name], capture_output=True)
 
+
 import fakeredis
 
 A_NAMES = ['teacher', 'admin']
@@ -89,7 +101,8 @@ def shared_fakeredis(monkeypatch):
     shared_client = fakeredis.FakeStrictRedis(server=server)
     from mongo.utils import RedisCache
     monkeypatch.setattr(
-        RedisCache, 'client',
+        RedisCache,
+        'client',
         property(lambda self: shared_client),
     )
 
@@ -140,9 +153,10 @@ class TestRunnerAuth:
         assert rv.status_code == 403
 
     def test_invalid_token_returns_403(self, client):
-        rv = client.get('/runner/jobs', headers={
-            'X-Runner-Token': 'wrong-token',
-        })
+        rv = client.get('/runner/jobs',
+                        headers={
+                            'X-Runner-Token': 'wrong-token',
+                        })
         assert rv.status_code == 403
 
     def test_valid_token_returns_200(self, client):
@@ -260,7 +274,8 @@ class TestGetJobCode:
         assert rv.status_code == 200
         assert rv.content_type == 'application/zip'
 
-    def test_code_download_by_non_claimer_returns_403(self, client, submission_id):
+    def test_code_download_by_non_claimer_returns_403(self, client,
+                                                      submission_id):
         # Claim by one runner
         client.post(
             f'/runner/jobs/{submission_id}/claim',

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,403 @@
+import itertools
+import pathlib
+import subprocess
+import time as _time
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from minio import Minio
+from mongo import *
+from mongo import engine
+import mongo.config
+from .base_tester import BaseTester
+from .utils import *
+from tests import utils
+
+
+@pytest.fixture(autouse=True, scope='session')
+def setup_minio():
+    """Override session-scoped minio fixture to start minio via Docker."""
+    container_name = 'test-minio-runner'
+    subprocess.run(
+        ['docker', 'rm', '-f', container_name],
+        capture_output=True,
+    )
+    proc = subprocess.run(
+        [
+            'docker', 'run', '-d',
+            '--name', container_name,
+            '-p', '19000:9000',
+            '-e', 'MINIO_ROOT_USER=minioadmin',
+            '-e', 'MINIO_ROOT_PASSWORD=minioadmin',
+            'minio/minio:latest', 'server', '/data', '--address', ':9000',
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f'Failed to start minio: {proc.stderr}'
+
+    # Wait for minio to be ready
+    for _ in range(30):
+        try:
+            import urllib.request
+            urllib.request.urlopen('http://localhost:19000/minio/health/live', timeout=2)
+            break
+        except Exception:
+            _time.sleep(1)
+    else:
+        raise TimeoutError('Minio did not start in time')
+
+    mongo.config.MINIO_ACCESS_KEY = 'minioadmin'
+    mongo.config.MINIO_SECRET_KEY = 'minioadmin'
+    mongo.config.MINIO_HOST = 'localhost:19000'
+    mongo.config.FLASK_DEBUG = True
+
+    client = Minio(
+        'localhost:19000',
+        access_key='minioadmin',
+        secret_key='minioadmin',
+        secure=False,
+    )
+    bucket = mongo.config.MINIO_BUCKET
+    if not client.bucket_exists(bucket):
+        client.make_bucket(bucket)
+    yield
+
+    subprocess.run(['docker', 'rm', '-f', container_name], capture_output=True)
+
+import fakeredis
+
+A_NAMES = ['teacher', 'admin']
+S_NAMES = {
+    'student': 'Chika.Fujiwara',
+    'student-2': 'Nico.Kurosawa',
+}
+
+# The default sandbox token from engine.SubmissionConfig
+RUNNER_TOKEN = 'KoNoSandboxDa'
+RUNNER_HEADERS = {
+    'X-Runner-Token': RUNNER_TOKEN,
+    'X-Runner-Name': 'test-runner',
+}
+
+
+@pytest.fixture(autouse=True)
+def shared_fakeredis(monkeypatch):
+    """Ensure all RedisCache instances share the same fakeredis server."""
+    server = fakeredis.FakeServer()
+    shared_client = fakeredis.FakeStrictRedis(server=server)
+    from mongo.utils import RedisCache
+    monkeypatch.setattr(
+        RedisCache, 'client',
+        property(lambda self: shared_client),
+    )
+
+
+@pytest.fixture(autouse=True)
+def runner_testcase_setup(
+    save_source,
+    make_course,
+):
+    BaseTester.setup_class()
+    src_dir = pathlib.Path('tests/src')
+    exts = ['.c', '.cpp', '.py', '.pdf']
+    for src in src_dir.iterdir():
+        if any([not src.suffix in exts, not src.is_file()]):
+            continue
+        save_source(
+            src.stem,
+            src.read_bytes(),
+            exts.index(src.suffix),
+        )
+    for name in A_NAMES:
+        make_course(username=name, students=S_NAMES)
+    yield
+    BaseTester.teardown_class()
+
+
+@pytest.fixture
+def submission_id(app, problem_ids, get_source):
+    """Create a single pending submission (status=-1) for testing."""
+    with app.app_context():
+        pids = problem_ids('teacher', 1, True)
+        pid = pids[0]
+        sub = Submission.add(
+            problem_id=pid,
+            username='student',
+            lang=2,
+            timestamp=datetime.now(),
+        )
+        sub.submit(get_source('base.py'))
+        return str(sub.obj.id)
+
+
+class TestRunnerAuth:
+    """Test runner authentication via X-Runner-Token."""
+
+    def test_missing_token_returns_403(self, client):
+        rv = client.get('/runner/jobs')
+        assert rv.status_code == 403
+
+    def test_invalid_token_returns_403(self, client):
+        rv = client.get('/runner/jobs', headers={
+            'X-Runner-Token': 'wrong-token',
+        })
+        assert rv.status_code == 403
+
+    def test_valid_token_returns_200(self, client):
+        rv = client.get('/runner/jobs', headers=RUNNER_HEADERS)
+        assert rv.status_code == 200
+
+
+class TestGetPendingJobs:
+    """Test GET /runner/jobs endpoint."""
+
+    def test_no_pending_jobs(self, client):
+        rv = client.get('/runner/jobs', headers=RUNNER_HEADERS)
+        assert rv.status_code == 200
+        data = rv.get_json()['data']
+        assert data['jobs'] == []
+
+    def test_returns_pending_submission(self, client, submission_id):
+        rv = client.get('/runner/jobs', headers=RUNNER_HEADERS)
+        assert rv.status_code == 200
+        data = rv.get_json()['data']
+        jobs = data['jobs']
+        assert len(jobs) >= 1
+        job_ids = [j['submissionId'] for j in jobs]
+        assert submission_id in job_ids
+
+    def test_excludes_claimed_jobs(self, client, submission_id):
+        # Claim the job first
+        engine.Submission.objects.get(id=submission_id).update(
+            claimed_by='other-runner',
+            claimed_at=datetime.now(),
+        )
+        rv = client.get('/runner/jobs', headers=RUNNER_HEADERS)
+        assert rv.status_code == 200
+        jobs = rv.get_json()['data']['jobs']
+        job_ids = [j['submissionId'] for j in jobs]
+        assert submission_id not in job_ids
+
+    def test_includes_expired_claims(self, client, submission_id):
+        # Claim with expired time
+        engine.Submission.objects.get(id=submission_id).update(
+            claimed_by='dead-runner',
+            claimed_at=datetime.now() - timedelta(seconds=700),
+        )
+        rv = client.get('/runner/jobs', headers=RUNNER_HEADERS)
+        assert rv.status_code == 200
+        jobs = rv.get_json()['data']['jobs']
+        job_ids = [j['submissionId'] for j in jobs]
+        assert submission_id in job_ids
+
+
+class TestClaimJob:
+    """Test POST /runner/jobs/<id>/claim endpoint."""
+
+    def test_claim_success(self, client, submission_id):
+        rv = client.post(
+            f'/runner/jobs/{submission_id}/claim',
+            headers=RUNNER_HEADERS,
+        )
+        assert rv.status_code == 200
+        data = rv.get_json()['data']
+        assert data['submissionId'] == submission_id
+        assert 'token' in data
+        assert 'meta' in data
+        assert 'language' in data['meta']
+        assert 'tasks' in data['meta']
+
+    def test_claim_nonexistent_returns_404(self, client):
+        rv = client.post(
+            '/runner/jobs/000000000000000000000000/claim',
+            headers=RUNNER_HEADERS,
+        )
+        assert rv.status_code == 404
+
+    def test_claim_already_claimed_returns_409(self, client, submission_id):
+        # First claim
+        rv = client.post(
+            f'/runner/jobs/{submission_id}/claim',
+            headers=RUNNER_HEADERS,
+        )
+        assert rv.status_code == 200
+
+        # Second claim by another runner
+        rv = client.post(
+            f'/runner/jobs/{submission_id}/claim',
+            headers={
+                'X-Runner-Token': RUNNER_TOKEN,
+                'X-Runner-Name': 'another-runner',
+            },
+        )
+        assert rv.status_code == 409
+
+    def test_claim_sets_claimed_by_field(self, client, submission_id):
+        client.post(
+            f'/runner/jobs/{submission_id}/claim',
+            headers=RUNNER_HEADERS,
+        )
+        sub = engine.Submission.objects.get(id=submission_id)
+        assert sub.claimed_by == 'test-runner'
+        assert sub.claimed_at is not None
+
+
+class TestGetJobCode:
+    """Test GET /runner/jobs/<id>/code endpoint."""
+
+    def test_code_download_by_claimer(self, client, submission_id):
+        # Claim first
+        client.post(
+            f'/runner/jobs/{submission_id}/claim',
+            headers=RUNNER_HEADERS,
+        )
+        rv = client.get(
+            f'/runner/jobs/{submission_id}/code',
+            headers=RUNNER_HEADERS,
+        )
+        assert rv.status_code == 200
+        assert rv.content_type == 'application/zip'
+
+    def test_code_download_by_non_claimer_returns_403(self, client, submission_id):
+        # Claim by one runner
+        client.post(
+            f'/runner/jobs/{submission_id}/claim',
+            headers=RUNNER_HEADERS,
+        )
+        # Try download by another
+        rv = client.get(
+            f'/runner/jobs/{submission_id}/code',
+            headers={
+                'X-Runner-Token': RUNNER_TOKEN,
+                'X-Runner-Name': 'another-runner',
+            },
+        )
+        assert rv.status_code == 403
+
+    def test_code_download_nonexistent_returns_404(self, client):
+        rv = client.get(
+            '/runner/jobs/000000000000000000000000/code',
+            headers=RUNNER_HEADERS,
+        )
+        assert rv.status_code == 404
+
+
+class TestHeartbeat:
+    """Test POST /runner/heartbeat endpoint."""
+
+    def test_heartbeat_extends_claim(self, client, submission_id):
+        # Claim first
+        client.post(
+            f'/runner/jobs/{submission_id}/claim',
+            headers=RUNNER_HEADERS,
+        )
+        old_sub = engine.Submission.objects.get(id=submission_id)
+        old_claimed_at = old_sub.claimed_at
+
+        # Send heartbeat
+        rv = client.post(
+            '/runner/heartbeat',
+            headers=RUNNER_HEADERS,
+            json={'submissionId': submission_id},
+        )
+        assert rv.status_code == 200
+
+        new_sub = engine.Submission.objects.get(id=submission_id)
+        assert new_sub.claimed_at >= old_claimed_at
+
+    def test_heartbeat_without_submission_id(self, client):
+        rv = client.post(
+            '/runner/heartbeat',
+            headers=RUNNER_HEADERS,
+            json={},
+        )
+        assert rv.status_code == 200
+
+    def test_heartbeat_by_non_claimer_returns_403(self, client, submission_id):
+        # Claim by one runner
+        client.post(
+            f'/runner/jobs/{submission_id}/claim',
+            headers=RUNNER_HEADERS,
+        )
+        # Heartbeat from different runner
+        rv = client.post(
+            '/runner/heartbeat',
+            headers={
+                'X-Runner-Token': RUNNER_TOKEN,
+                'X-Runner-Name': 'another-runner',
+            },
+            json={'submissionId': submission_id},
+        )
+        assert rv.status_code == 403
+
+
+class TestJobComplete:
+    """Test PUT /runner/jobs/<id>/complete endpoint."""
+
+    def test_complete_missing_body_returns_400(self, client, submission_id):
+        rv = client.put(
+            f'/runner/jobs/{submission_id}/complete',
+            headers=RUNNER_HEADERS,
+            content_type='application/json',
+        )
+        assert rv.status_code == 400
+
+    def test_complete_missing_fields_returns_400(self, client, submission_id):
+        rv = client.put(
+            f'/runner/jobs/{submission_id}/complete',
+            headers=RUNNER_HEADERS,
+            json={'tasks': []},
+        )
+        assert rv.status_code == 400
+
+    def test_complete_invalid_token_returns_403(self, client, submission_id):
+        rv = client.put(
+            f'/runner/jobs/{submission_id}/complete',
+            headers=RUNNER_HEADERS,
+            json={
+                'tasks': [],
+                'token': 'invalid-token',
+            },
+        )
+        assert rv.status_code == 403
+
+    def test_complete_with_valid_token(self, client, submission_id):
+        # Claim to get token
+        rv = client.post(
+            f'/runner/jobs/{submission_id}/claim',
+            headers=RUNNER_HEADERS,
+        )
+        token = rv.get_json()['data']['token']
+        tasks = rv.get_json()['data']['meta']['tasks']
+
+        # Build result matching the task structure
+        result_tasks = []
+        for task in tasks:
+            cases = []
+            for _ in range(task['caseCount']):
+                cases.append({
+                    'exitCode': 0,
+                    'status': 'AC',
+                    'stdout': 'output',
+                    'stderr': '',
+                    'execTime': 100,
+                    'memoryUsage': 1024,
+                })
+            result_tasks.append(cases)
+
+        rv = client.put(
+            f'/runner/jobs/{submission_id}/complete',
+            headers=RUNNER_HEADERS,
+            json={
+                'tasks': result_tasks,
+                'token': token,
+            },
+        )
+        assert rv.status_code == 200
+
+        # Verify submission status updated
+        sub = engine.Submission.objects.get(id=submission_id)
+        assert sub.status != -1  # no longer pending
+        assert sub.claimed_by is None  # claim cleared


### PR DESCRIPTION
Add a new /runner API blueprint that allows sandbox instances to operate as pull-based runners instead of receiving pushed submissions. Runners poll for pending jobs, claim them, download code/testdata, and report results back — similar to GitHub Actions self-hosted runners.

Changes:
- model/runner.py: New runner API with /jobs, /claim, /code, /testdata, /complete, and /heartbeat endpoints
- mongo/engine.py: Add claimed_by/claimed_at fields to Submission
- mongo/submission.py: Support RUNNER_MODE=pull env var in send()
- app.py: Register runner_api blueprint at /runner

https://claude.ai/code/session_01CD3q84rDaDXMnAmQVh58qR