### PR TITLE
refactor: split multi-method route handlers

### DIFF
--- a/model/announcement.py
+++ b/model/announcement.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from flask import Blueprint, request
+from flask import Blueprint
 
 from mongo import *
 from mongo.utils import *
@@ -30,99 +30,96 @@ def get_sys_ann(ann_id=None):
     return HTTPResponse('Sys Ann bro', data=data)
 
 
-@ann_api.route('/', methods=['POST', 'PUT', 'DELETE'])
-@course_api.route('/<course_name>/ann', methods=['GET'])
-@ann_api.route('/<course_name>/<ann_id>', methods=['GET'])
+@course_api.get('/<course_name>/ann')
+@ann_api.get('/<course_name>/<ann_id>')
 @login_required
-def anncmnt(user, course_name=None, ann_id=None):
+def get_announcements(user, course_name=None, ann_id=None):
+    # Get an announcement list
+    try:
+        anns = Announcement.ann_list(user.obj, course_name or 'Public')
+    except (DoesNotExist, ValidationError):
+        return HTTPError('Cannot Access a Announcement', 403)
+    if anns is None:
+        return HTTPError('Announcement Not Found', 404)
+    data = [{
+        'annId': str(an.id),
+        'title': an.title,
+        'createTime': int(an.create_time.timestamp()),
+        'updateTime': int(an.update_time.timestamp()),
+        'creator': an.creator.info,
+        'updater': an.updater.info,
+        'markdown': an.markdown,
+        'pinned': an.pinned
+    } for an in anns if ann_id is None or str(an.id) == ann_id]
+    return HTTPResponse('Announcement List', data=data)
 
-    def get_anns():
-        # Get an announcement list
-        try:
-            anns = Announcement.ann_list(user.obj, course_name or 'Public')
-        except (DoesNotExist, ValidationError):
-            return HTTPError('Cannot Access a Announcement', 403)
-        if anns is None:
-            return HTTPError('Announcement Not Found', 404)
-        data = [{
-            'annId': str(an.id),
-            'title': an.title,
-            'createTime': int(an.create_time.timestamp()),
-            'updateTime': int(an.update_time.timestamp()),
-            'creator': an.creator.info,
-            'updater': an.updater.info,
-            'markdown': an.markdown,
-            'pinned': an.pinned
-        } for an in anns if ann_id == None or str(an.id) == ann_id]
-        return HTTPResponse('Announcement List', data=data)
 
-    @Request.json('title', 'markdown', 'course_name', 'pinned')
-    def create(title, markdown, course_name, pinned):
-        # Create a new announcement
-        try:
-            ann = Announcement.new_ann(
-                title=title,
-                creator=user.obj,
-                markdown=markdown,
-                pinned=pinned,
-                course=course_name or 'Public',
-            )
-        except ValidationError as ve:
-            return HTTPError('Failed to Create Announcement',
-                             400,
-                             data=ve.to_dict())
-        if ann is None:
-            return HTTPError('Failed to Create Announcement', 403)
-        data = {
-            'annId': str(ann.id),
-            'createTime': int(ann.create_time.timestamp())
-        }
-        return HTTPResponse('Announcement Created', data=data)
-
-    @Request.json('ann_id', 'title', 'markdown', 'pinned')
-    def update(ann_id, title, markdown, pinned):
-        # Update an announcement
-        ann = Announcement(ann_id)
-        if not ann:
-            return HTTPError('Announcement Not Found', 404)
-
-        course = Course(ann.course)
-        if not course.permission(user, Course.Permission.GRADE):
-            return HTTPError('Failed to Update Announcement', 403)
-        try:
-            ann.update(
-                title=title,
-                markdown=markdown,
-                update_time=datetime.now(),
-                updater=user.obj,
-                pinned=pinned,
-            )
-        except ValidationError as ve:
-            return HTTPError(
-                'Failed to Update Announcement',
-                400,
-                data=ve.to_dict(),
-            )
-        return HTTPResponse('Updated')
-
-    @Request.json('ann_id')
-    def delete(ann_id):
-        # Delete an announcement
-        ann = Announcement(ann_id)
-        if not ann:
-            return HTTPError('Announcement Not Found', 404)
-
-        course = Course(ann.course)
-        if not course.permission(user, Course.Permission.GRADE):
-            return HTTPError('Failed to Delete Announcement', 403)
-        ann.update(status=1)
-        return HTTPResponse('Deleted')
-
-    methods = {
-        'GET': get_anns,
-        'POST': create,
-        'PUT': update,
-        'DELETE': delete
+@ann_api.post('/')
+@login_required
+@Request.json('title', 'markdown', 'course_name', 'pinned')
+def create_announcement(user, title, markdown, course_name, pinned):
+    # Create a new announcement
+    try:
+        ann = Announcement.new_ann(
+            title=title,
+            creator=user.obj,
+            markdown=markdown,
+            pinned=pinned,
+            course=course_name or 'Public',
+        )
+    except ValidationError as ve:
+        return HTTPError('Failed to Create Announcement',
+                         400,
+                         data=ve.to_dict())
+    if ann is None:
+        return HTTPError('Failed to Create Announcement', 403)
+    data = {
+        'annId': str(ann.id),
+        'createTime': int(ann.create_time.timestamp())
     }
+    return HTTPResponse('Announcement Created', data=data)
 
-    return methods[request.method]()
+
+@ann_api.put('/')
+@login_required
+@Request.json('ann_id', 'title', 'markdown', 'pinned')
+def update_announcement(user, ann_id, title, markdown, pinned):
+    # Update an announcement
+    ann = Announcement(ann_id)
+    if not ann:
+        return HTTPError('Announcement Not Found', 404)
+
+    course = Course(ann.course)
+    if not course.permission(user, Course.Permission.GRADE):
+        return HTTPError('Failed to Update Announcement', 403)
+    try:
+        ann.update(
+            title=title,
+            markdown=markdown,
+            update_time=datetime.now(),
+            updater=user.obj,
+            pinned=pinned,
+        )
+    except ValidationError as ve:
+        return HTTPError(
+            'Failed to Update Announcement',
+            400,
+            data=ve.to_dict(),
+        )
+    return HTTPResponse('Updated')
+
+
+@ann_api.delete('/')
+@login_required
+@Request.json('ann_id')
+def delete_announcement(user, ann_id):
+    # Delete an announcement
+    ann = Announcement(ann_id)
+    if not ann:
+        return HTTPError('Announcement Not Found', 404)
+
+    course = Course(ann.course)
+    if not course.permission(user, Course.Permission.GRADE):
+        return HTTPError('Failed to Delete Announcement', 403)
+    ann.update(status=1)
+    return HTTPResponse('Deleted')

--- a/model/auth.py
+++ b/model/auth.py
@@ -86,48 +86,39 @@ def identity_verify(*roles):
 
 def get_verify_link(user: User) -> str:
     return url_for(
-        'auth_api.active',
+        'auth_api.active_redirect',
         _external=True,
         token=user.cookie,
     )
 
 
-@auth_api.route('/session', methods=['GET', 'POST'])
-def session():
-    '''Create a session or remove a session.
-    Request methods:
-        GET: Logout
-        POST: Login
+@auth_api.get('/session')
+def logout():
+    '''Logout a user.
+    Returns:
+        - 200 Logout Success
     '''
+    cookies = {'jwt': None, 'piann': None}
+    return HTTPResponse('Goodbye', cookies=cookies)
 
-    def logout():
-        '''Logout a user.
-        Returns:
-            - 200 Logout Success
-        '''
-        cookies = {'jwt': None, 'piann': None}
-        return HTTPResponse('Goodbye', cookies=cookies)
 
-    @Request.json('username: str', 'password: str')
-    def login(username, password):
-        '''Login a user.
-        Returns:
-            - 400 Incomplete Data
-            - 403 Login Failed
-        '''
-        ip_addr = request.headers.get('cf-connecting-ip', request.remote_addr)
-        try:
-            user = User.login(username, password, ip_addr)
-        except DoesNotExist:
-            return HTTPError('Login Failed', 403)
-        if not user.active:
-            return HTTPError('Invalid User', 403)
-        cookies = {'piann_httponly': user.secret, 'jwt': user.cookie}
-        return HTTPResponse('Login Success', cookies=cookies)
-
-    methods = {'GET': logout, 'POST': login}
-
-    return methods[request.method]()
+@auth_api.post('/session')
+@Request.json('username: str', 'password: str')
+def login(username, password):
+    '''Login a user.
+    Returns:
+        - 400 Incomplete Data
+        - 403 Login Failed
+    '''
+    ip_addr = request.headers.get('cf-connecting-ip', request.remote_addr)
+    try:
+        user = User.login(username, password, ip_addr)
+    except DoesNotExist:
+        return HTTPError('Login Failed', 403)
+    if not user.active:
+        return HTTPError('Invalid User', 403)
+    cookies = {'piann_httponly': user.secret, 'jwt': user.cookie}
+    return HTTPResponse('Login Success', cookies=cookies)
 
 
 @auth_api.route('/signup', methods=['POST'])
@@ -201,46 +192,40 @@ def resend_email(email):
     return HTTPResponse('Email Has Been Resent')
 
 
-@auth_api.route('/active', methods=['POST'])
-@auth_api.route('/active/<token>', methods=['GET'])
-def active(token=None):
-    '''Activate a user.
+@auth_api.get('/active/<token>')
+def active_redirect(token):
+    '''Redirect user to active page.
     '''
+    json = jwt_decode(token)
+    if json is None:
+        return HTTPError('Invalid Token', 403)
+    user = User(json['data']['username'])
+    cookies = {'piann_httponly': user.secret, 'jwt': user.cookie}
+    return HTTPRedirect('/email_verify', cookies=cookies)
 
-    @Request.json('profile: dict', 'agreement: bool')
-    @Request.cookies(vars_dict={'token': 'piann'})
-    def update(profile, agreement, token):
-        '''User: active: false -> true
-        '''
-        if agreement is not True:
-            return HTTPError('Not Confirm the Agreement', 403)
-        json = jwt_decode(token)
-        if json is None or not json.get('secret'):
-            return HTTPError('Invalid Token.', 403)
-        user = User(json['data']['username'])
-        if not user:
-            return HTTPError('User Not Exists', 400)
-        if user.active:
-            return HTTPError('User Has Been Actived', 400)
-        try:
-            user.activate(profile)
-        except engine.DoesNotExist as e:
-            return HTTPError(str(e), 404)
-        cookies = {'jwt': user.cookie}
-        return HTTPResponse('User Is Now Active', cookies=cookies)
 
-    def redir():
-        '''Redirect user to active page.
-        '''
-        json = jwt_decode(token)
-        if json is None:
-            return HTTPError('Invalid Token', 403)
-        user = User(json['data']['username'])
-        cookies = {'piann_httponly': user.secret, 'jwt': user.cookie}
-        return HTTPRedirect('/email_verify', cookies=cookies)
-
-    methods = {'GET': redir, 'POST': update}
-    return methods[request.method]()
+@auth_api.post('/active')
+@Request.json('profile: dict', 'agreement: bool')
+@Request.cookies(vars_dict={'token': 'piann'})
+def activate_user(profile, agreement, token):
+    '''User: active: false -> true
+    '''
+    if agreement is not True:
+        return HTTPError('Not Confirm the Agreement', 403)
+    json = jwt_decode(token)
+    if json is None or not json.get('secret'):
+        return HTTPError('Invalid Token.', 403)
+    user = User(json['data']['username'])
+    if not user:
+        return HTTPError('User Not Exists', 400)
+    if user.active:
+        return HTTPError('User Has Been Actived', 400)
+    try:
+        user.activate(profile)
+    except engine.DoesNotExist as e:
+        return HTTPError(str(e), 404)
+    cookies = {'jwt': user.cookie}
+    return HTTPResponse('User Is Now Active', cookies=cookies)
 
 
 @auth_api.route('/password-recovery', methods=['POST'])

--- a/model/course.py
+++ b/model/course.py
@@ -67,7 +67,7 @@ def modify_courses(user, course, new_course, teacher):
     return HTTPResponse('Success.')
 
 
-@course_api.route('/<course_name>', methods=['GET', 'PUT'])
+@course_api.get('/<course_name>')
 @login_required
 def get_course(user, course_name):
     course = Course(course_name)
@@ -78,48 +78,54 @@ def get_course(user, course_name):
     if not course.permission(user, Course.Permission.VIEW):
         return HTTPError('You are not in this course.', 403)
 
-    @Request.json('TAs', 'student_nicknames')
-    def modify_course(TAs, student_nicknames):
-        if not course.permission(user, Course.Permission.MODIFY):
-            return HTTPError('Forbidden.', 403)
-        else:
-            tas = []
-            for ta in TAs:
-                permit_user = User(ta).obj
-                if not User(ta):
-                    return HTTPResponse(f'User: {ta} not found.', 404)
-                tas.append(permit_user)
-
-            for permit_user in set(course.tas) - set(tas):
-                course.remove_user(permit_user)
-            for permit_user in set(tas) - set(course.tas):
-                course.add_user(permit_user)
-            course.tas = tas
-
-        try:
-            course.update_student_namelist(student_nicknames)
-        except engine.DoesNotExist as e:
-            return HTTPError(str(e), 404)
-        return HTTPResponse('Success.')
-
-    if request.method == 'GET':
-        return HTTPResponse(
-            'Success.',
-            data={
-                "teacher": course.teacher.info,
-                "TAs": [ta.info for ta in course.tas],
-                "students":
-                [User(name).info for name in course.student_nicknames]
-            },
-        )
-    else:
-        return modify_course()
+    return HTTPResponse(
+        'Success.',
+        data={
+            "teacher": course.teacher.info,
+            "TAs": [ta.info for ta in course.tas],
+            "students": [User(name).info for name in course.student_nicknames]
+        },
+    )
 
 
-@course_api.route('/<course_name>/grade/<student>',
-                  methods=['GET', 'POST', 'PUT', 'DELETE'])
+@course_api.put('/<course_name>')
 @login_required
-def grading(user, course_name, student):
+@Request.json('TAs', 'student_nicknames')
+def update_course(user, course_name, TAs, student_nicknames):
+    course = Course(course_name)
+
+    if not course:
+        return HTTPError('Course not found.', 404)
+
+    if not course.permission(user, Course.Permission.VIEW):
+        return HTTPError('You are not in this course.', 403)
+
+    if not course.permission(user, Course.Permission.MODIFY):
+        return HTTPError('Forbidden.', 403)
+
+    tas = []
+    for ta in TAs:
+        permit_user = User(ta).obj
+        if not User(ta):
+            return HTTPResponse(f'User: {ta} not found.', 404)
+        tas.append(permit_user)
+
+    for permit_user in set(course.tas) - set(tas):
+        course.remove_user(permit_user)
+    for permit_user in set(tas) - set(course.tas):
+        course.add_user(permit_user)
+    course.tas = tas
+
+    try:
+        course.update_student_namelist(student_nicknames)
+    except engine.DoesNotExist as e:
+        return HTTPError(str(e), 404)
+    return HTTPResponse('Success.')
+
+
+@course_api.get('/<course_name>/grade/<student>')
+@login_required
+def get_grade(user, course_name, student):
     course = Course(course_name)
 
     if not course:
@@ -128,75 +134,107 @@ def grading(user, course_name, student):
         return HTTPError('You are not in this course.', 403)
     if student not in course.student_nicknames.keys():
         return HTTPError('The student is not in the course.', 404)
-    if course.permission(user, Course.Permission.SCORE) and \
-        (user.username != student or request.method != 'GET'):
+    if course.permission(user,
+                         Course.Permission.SCORE) and user.username != student:
         return HTTPError('You can only view your score.', 403)
 
-    def get_score():
-        return HTTPResponse(
-            'Success.',
-            data=[{
-                'title': score['title'],
-                'content': score['content'],
-                'score': score['score'],
-                'timestamp': score['timestamp'].timestamp()
-            } for score in course.student_scores.get(student, [])])
+    return HTTPResponse('Success.',
+                        data=[{
+                            'title': score['title'],
+                            'content': score['content'],
+                            'score': score['score'],
+                            'timestamp': score['timestamp'].timestamp()
+                        } for score in course.student_scores.get(student, [])])
 
-    @Request.json('title', 'content', 'score')
-    def add_score(title, content, score):
-        score_list = course.student_scores.get(student, [])
-        if title in [score['title'] for score in score_list]:
+
+@course_api.post('/<course_name>/grade/<student>')
+@login_required
+@Request.json('title', 'content', 'score')
+def add_grade(user, course_name, student, title, content, score):
+    course = Course(course_name)
+
+    if not course:
+        return HTTPError('Course not found.', 404)
+    if not course.permission(user, Course.Permission.VIEW):
+        return HTTPError('You are not in this course.', 403)
+    if student not in course.student_nicknames.keys():
+        return HTTPError('The student is not in the course.', 404)
+    if course.permission(user, Course.Permission.SCORE):
+        return HTTPError('You can only view your score.', 403)
+
+    score_list = course.student_scores.get(student, [])
+    if title in [score['title'] for score in score_list]:
+        return HTTPError('This title is taken.', 400)
+    score_list.append({
+        'title': title,
+        'content': content,
+        'score': score,
+        'timestamp': datetime.now()
+    })
+    course.student_scores[student] = score_list
+    course.save()
+    return HTTPResponse('Success.')
+
+
+@course_api.put('/<course_name>/grade/<student>')
+@login_required
+@Request.json('title', 'new_title', 'content', 'score')
+def update_grade(user, course_name, student, title, new_title, content, score):
+    course = Course(course_name)
+
+    if not course:
+        return HTTPError('Course not found.', 404)
+    if not course.permission(user, Course.Permission.VIEW):
+        return HTTPError('You are not in this course.', 403)
+    if student not in course.student_nicknames.keys():
+        return HTTPError('The student is not in the course.', 404)
+    if course.permission(user, Course.Permission.SCORE):
+        return HTTPError('You can only view your score.', 403)
+
+    score_list = course.student_scores.get(student, [])
+    title_list = [score['title'] for score in score_list]
+    if title not in title_list:
+        return HTTPError('Score not found.', 404)
+    index = title_list.index(title)
+    if new_title is not None:
+        if new_title in title_list:
             return HTTPError('This title is taken.', 400)
-        score_list.append({
-            'title': title,
-            'content': content,
-            'score': score,
-            'timestamp': datetime.now()
-        })
-        course.student_scores[student] = score_list
-        course.save()
-        return HTTPResponse('Success.')
-
-    @Request.json('title', 'new_title', 'content', 'score')
-    def modify_score(title, new_title, content, score):
-        score_list = course.student_scores.get(student, [])
-        title_list = [score['title'] for score in score_list]
-        if title not in title_list:
-            return HTTPError('Score not found.', 404)
-        index = title_list.index(title)
-        if new_title is not None:
-            if new_title in title_list:
-                return HTTPError('This title is taken.', 400)
-            title = new_title
-        score_list[index] = {
-            'title': title,
-            'content': content,
-            'score': score,
-            'timestamp': datetime.now()
-        }
-        course.student_scores[student] = score_list
-        course.save()
-        return HTTPResponse('Success.')
-
-    @Request.json('title')
-    def delete_score(title):
-        score_list = course.student_scores.get(student, [])
-        title_list = [score['title'] for score in score_list]
-        if title not in title_list:
-            return HTTPError('Score not found.', 404)
-        index = title_list.index(title)
-        del score_list[index]
-        course.student_scores[student] = score_list
-        course.save()
-        return HTTPResponse('Success.')
-
-    methods = {
-        'GET': get_score,
-        'POST': add_score,
-        'PUT': modify_score,
-        'DELETE': delete_score
+        title = new_title
+    score_list[index] = {
+        'title': title,
+        'content': content,
+        'score': score,
+        'timestamp': datetime.now()
     }
-    return methods[request.method]()
+    course.student_scores[student] = score_list
+    course.save()
+    return HTTPResponse('Success.')
+
+
+@course_api.delete('/<course_name>/grade/<student>')
+@login_required
+@Request.json('title')
+def delete_grade(user, course_name, student, title):
+    course = Course(course_name)
+
+    if not course:
+        return HTTPError('Course not found.', 404)
+    if not course.permission(user, Course.Permission.VIEW):
+        return HTTPError('You are not in this course.', 403)
+    if student not in course.student_nicknames.keys():
+        return HTTPError('The student is not in the course.', 404)
+    if course.permission(user, Course.Permission.SCORE):
+        return HTTPError('You can only view your score.', 403)
+
+    score_list = course.student_scores.get(student, [])
+    title_list = [score['title'] for score in score_list]
+    if title not in title_list:
+        return HTTPError('Score not found.', 404)
+    index = title_list.index(title)
+    del score_list[index]
+    course.student_scores[student] = score_list
+    course.save()
+    return HTTPResponse('Success.')
 
 
 @course_api.route('/<course_name>/scoreboard', methods=['GET'])

--- a/model/homework.py
+++ b/model/homework.py
@@ -1,5 +1,5 @@
 from typing import List
-from flask import Blueprint, request
+from flask import Blueprint
 from mongo import *
 from mongo import engine
 from .utils import *
@@ -11,61 +11,39 @@ __all__ = ['homework_api']
 homework_api = Blueprint('homework_api', __name__)
 
 
-@homework_api.route('/', methods=['POST'])
-@homework_api.route('/<homework_id>', methods=['PUT', 'DELETE', 'GET'])
+@homework_api.post('/')
 @login_required
-def homework_entry(user, homework_id=None):
-    '''
-    apply a operation to single homework
-    '''
-
-    @Request.json('name', 'course_name', 'markdown', 'start', 'end',
-                  'problem_ids', 'scoreboard_status', 'penalty')
-    def add_homework(course_name, name, markdown, start, end, problem_ids,
-                     scoreboard_status, penalty):
-        try:
-            homework = Homework.add(
-                user=user,
-                hw_name=name,
-                markdown=markdown,
-                scoreboard_status=scoreboard_status,
-                course_name=course_name,
-                problem_ids=problem_ids or [],
-                start=start,
-                end=end,
-                penalty=penalty,
-            )
-        except NameError:
-            return HTTPError('user must be the teacher or ta of this course',
-                             403)
-        except FileExistsError:
-            return HTTPError('homework exists in this course', 400)
-        return HTTPResponse('Add homework Success')
-
-    @Request.json('name', 'markdown', 'start', 'end', 'problem_ids',
-                  'scoreboard_status', 'penalty')
-    def update_homework(name, markdown, start, end, problem_ids,
-                        scoreboard_status, penalty):
-        homework = Homework.update(
+@Request.json('name', 'course_name', 'markdown', 'start', 'end', 'problem_ids',
+              'scoreboard_status', 'penalty')
+def create_homework(user, course_name, name, markdown, start, end, problem_ids,
+                    scoreboard_status, penalty):
+    try:
+        homework = Homework.add(
             user=user,
-            homework_id=homework_id,
+            hw_name=name,
             markdown=markdown,
-            new_hw_name=name,
+            scoreboard_status=scoreboard_status,
+            course_name=course_name,
+            problem_ids=problem_ids or [],
             start=start,
             end=end,
-            problem_ids=problem_ids,
-            scoreboard_status=scoreboard_status,
             penalty=penalty,
         )
-        return HTTPResponse('Update homework Success')
+    except NameError:
+        return HTTPError('user must be the teacher or ta of this course', 403)
+    except FileExistsError:
+        return HTTPError('homework exists in this course', 400)
+    except engine.DoesNotExist as e:
+        return HTTPError(str(e), 404)
+    except (PermissionError, engine.NotUniqueError) as e:
+        return HTTPError(str(e), 403)
+    return HTTPResponse('Add homework Success')
 
-    def delete_homework():
-        homework = Homework(homework_id)
-        homework = homework.delete_problems(user=user,
-                                            course=homework.course_id)
-        return HTTPResponse('Delete homework Success')
 
-    def get_homework():
+@homework_api.get('/<homework_id>')
+@login_required
+def get_homework(user, homework_id):
+    try:
         homework = Homework.get_by_id(homework_id)
         ret = {
             'name':
@@ -84,21 +62,50 @@ def homework_entry(user, homework_id=None):
             'penalty':
             homework.penalty if hasattr(homework, 'penalty') else None,
         }
-        return HTTPResponse('get homework', data=ret)
-
-    handler = {
-        'GET': get_homework,
-        'POST': add_homework,
-        'PUT': update_homework,
-        'DELETE': delete_homework
-    }
-
-    try:
-        return handler[request.method]()
     except engine.DoesNotExist as e:
         return HTTPError(str(e), 404)
     except (PermissionError, engine.NotUniqueError) as e:
         return HTTPError(str(e), 403)
+    return HTTPResponse('get homework', data=ret)
+
+
+@homework_api.put('/<homework_id>')
+@login_required
+@Request.json('name', 'markdown', 'start', 'end', 'problem_ids',
+              'scoreboard_status', 'penalty')
+def update_homework(user, homework_id, name, markdown, start, end, problem_ids,
+                    scoreboard_status, penalty):
+    try:
+        homework = Homework.update(
+            user=user,
+            homework_id=homework_id,
+            markdown=markdown,
+            new_hw_name=name,
+            start=start,
+            end=end,
+            problem_ids=problem_ids,
+            scoreboard_status=scoreboard_status,
+            penalty=penalty,
+        )
+    except engine.DoesNotExist as e:
+        return HTTPError(str(e), 404)
+    except (PermissionError, engine.NotUniqueError) as e:
+        return HTTPError(str(e), 403)
+    return HTTPResponse('Update homework Success')
+
+
+@homework_api.delete('/<homework_id>')
+@login_required
+def delete_homework(user, homework_id):
+    try:
+        homework = Homework(homework_id)
+        homework = homework.delete_problems(user=user,
+                                            course=homework.course_id)
+    except engine.DoesNotExist as e:
+        return HTTPError(str(e), 404)
+    except (PermissionError, engine.NotUniqueError) as e:
+        return HTTPError(str(e), 403)
+    return HTTPResponse('Delete homework Success')
 
 
 @course_api.route('/<course_name>/homework', methods=['GET'])

--- a/model/submission.py
+++ b/model/submission.py
@@ -464,65 +464,64 @@ def rejudge(user, submission: Submission):
         return HTTPError('Some error occurred, please contact the admin', 500)
 
 
-@submission_api.route('/config', methods=['GET', 'PUT'])
+@submission_api.get('/config')
 @login_required
 @identity_verify(0)
-def config(user):
+def get_config(user):
     config = Submission.config()
+    ret = config.to_mongo()
+    del ret['_cls']
+    del ret['_id']
+    return HTTPResponse('success.', data=ret)
 
-    def get_config():
-        ret = config.to_mongo()
-        del ret['_cls']
-        del ret['_id']
-        return HTTPResponse('success.', data=ret)
 
-    @Request.json('rate_limit: int', 'sandbox_instances: list')
-    def modify_config(rate_limit, sandbox_instances):
-        # try to convert json object to Sandbox instance
-        try:
-            sandbox_instances = [
-                *map(
-                    lambda s: engine.Sandbox(**s),
-                    sandbox_instances,
-                )
-            ]
-        except engine.ValidationError as e:
+@submission_api.put('/config')
+@login_required
+@identity_verify(0)
+@Request.json('rate_limit: int', 'sandbox_instances: list')
+def update_config(user, rate_limit, sandbox_instances):
+    config = Submission.config()
+    # try to convert json object to Sandbox instance
+    try:
+        sandbox_instances = [
+            *map(
+                lambda s: engine.Sandbox(**s),
+                sandbox_instances,
+            )
+        ]
+    except engine.ValidationError as e:
+        return HTTPError(
+            'wrong Sandbox schema',
+            400,
+            data=e.to_dict(),
+        )
+    # skip if during testing
+    if not current_app.config['TESTING']:
+        resps = []
+        # check sandbox status
+        for sb in sandbox_instances:
+            resp = rq.get(f'{sb.url}/status')
+            if not resp.ok:
+                resps.append((sb.name, resp))
+        # some exception occurred
+        if len(resps) != 0:
             return HTTPError(
-                'wrong Sandbox schema',
+                'some error occurred when check sandbox status',
                 400,
-                data=e.to_dict(),
+                data=[{
+                    'name': name,
+                    'statusCode': resp.status_code,
+                    'response': resp.text,
+                } for name, resp in resps],
             )
-        # skip if during testing
-        if not current_app.config['TESTING']:
-            resps = []
-            # check sandbox status
-            for sb in sandbox_instances:
-                resp = rq.get(f'{sb.url}/status')
-                if not resp.ok:
-                    resps.append((sb.name, resp))
-            # some exception occurred
-            if len(resps) != 0:
-                return HTTPError(
-                    'some error occurred when check sandbox status',
-                    400,
-                    data=[{
-                        'name': name,
-                        'statusCode': resp.status_code,
-                        'response': resp.text,
-                    } for name, resp in resps],
-                )
-        try:
-            config.update(
-                rate_limit=rate_limit,
-                sandbox_instances=sandbox_instances,
-            )
-        except ValidationError as e:
-            return HTTPError(str(e), 400)
-
-        return HTTPResponse('success.')
-
-    methods = {'GET': get_config, 'PUT': modify_config}
-    return methods[request.method]()
+    try:
+        config.update(
+            rate_limit=rate_limit,
+            sandbox_instances=sandbox_instances,
+        )
+    except ValidationError as e:
+        return HTTPError(str(e), 400)
+    return HTTPResponse('success.')
 
 
 @submission_api.post('/<submission>/migrate-code')


### PR DESCRIPTION
Promote inner HTTP-method dispatch functions to top-level route functions using Flask 3.x shorthand decorators (@blueprint.get/post/ put/delete). Affected files:

- model/auth.py: session() → logout()/login(), active() → active_redirect()/activate_user()
- model/submission.py: config() → get_config()/update_config()
- model/course.py: get_course() → get_course()/update_course(), grading() → get_grade()/add_grade()/update_grade()/delete_grade()
- model/homework.py: homework_entry() → create_homework()/get_homework()/update_homework()/delete_homework()
- model/announcement.py: anncmnt() → get_announcements()/create_announcement()/update_announcement()/delete_announcement()

No behaviour changes; all 441 tests pass.