### PR TITLE
ci: upgrade all GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -10,11 +10,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Install Poetry
         run: pipx install poetry
       - name: Setup Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: "poetry"

--- a/.github/workflows/generate-coverage-badge.yml
+++ b/.github/workflows/generate-coverage-badge.yml
@@ -9,11 +9,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Install Poetry
         run: pipx install poetry
       - name: Setup Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: "poetry"
@@ -33,7 +33,7 @@ jobs:
       - name: Remove gitignore
         run: rm report/.gitignore
       - name: Publish coverage report to gh-pages branch
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./report

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -22,16 +22,16 @@ jobs:
 
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -39,18 +39,20 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # set latest tag for default branch
           tags: type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: production
           push: true
+          # keep single-manifest output; v4+ provenance adds unknown/unknown entries on ghcr
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Upgrade all actions in the three workflows (CI, Generate Coverage Badge, Publish Docker Image) to current major versions:

- actions/checkout v3 -> v7 (deprecated node16 generation, the only one with real expiry pressure)
- actions/setup-python v4 -> v7
- docker/setup-qemu-action, docker/setup-buildx-action v2 -> v4
- docker/login-action v2 -> v4
- docker/metadata-action v4 -> v6
- docker/build-push-action v3 -> v7, with `provenance: false` so ghcr manifests stay free of `unknown/unknown` entries
- peaceiris/actions-gh-pages v3 -> v4

`tj-actions/coverage-badge-py@v2` is already at its current major, left as is.

Closes #346