### PR TITLE
ci: generate coverage badge with locked coverage-badge, drop tj-actions

### DIFF
--- a/.github/workflows/generate-coverage-badge.yml
+++ b/.github/workflows/generate-coverage-badge.yml
@@ -27,9 +27,7 @@ jobs:
           poetry run coverage report
       # coverage-report
       - name: Coverage Badge
-        uses: tj-actions/coverage-badge-py@v2
-        with:
-          output: report/coverage.svg
+        run: poetry run coverage-badge -o report/coverage.svg
       - name: Remove gitignore
         run: rm report/.gitignore
       - name: Publish coverage report to gh-pages branch

--- a/poetry.lock
+++ b/poetry.lock
@@ -446,6 +446,22 @@ files = [
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "coverage-badge"
+version = "1.1.2"
+description = "Generate coverage badges for Coverage.py."
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "coverage_badge-1.1.2-py2.py3-none-any.whl", hash = "sha256:d8413ce51c91043a1692b943616b450868cbeeb0ea6a0c54a32f8318c9c96ff7"},
+    {file = "coverage_badge-1.1.2.tar.gz", hash = "sha256:fe7ed58a3b72dad85a553b64a99e963dea3847dcd0b8ddd2b38a00333618642c"},
+]
+
+[package.dependencies]
+coverage = "*"
+setuptools = "*"
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 description = "Distribution utilities"
@@ -1592,6 +1608,27 @@ files = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "81.0.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6"},
+    {file = "setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.13.0) ; sys_platform != \"cygwin\""]
+core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.18.*)", "pytest-mypy"]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -2169,4 +2206,4 @@ platformdirs = ">=3.5.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "c1a7f1b715a05ee524a7a3ab567dbd117f7c8572800285c9e7425d2aeb9fd478"
+content-hash = "24f89be08124671130842e4f8254ce485f5942d56908d131a09ff42ffadf59c9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ fakeredis = "^1.9"
 toml = "^0.10"
 pytest-cov = "^3.0"
 testcontainers = {extras = ["minio"], version = "^4.10.0"}
+coverage-badge = "^1.1.2"
+# coverage-badge imports pkg_resources, removed in setuptools 82
+setuptools = "<82"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Closes #347

## What

- Remove `tj-actions/coverage-badge-py@v2` from the Generate Coverage Badge workflow. The tj-actions org had a supply chain compromise in March 2025, and the action is only a thin wrapper around the `coverage-badge` pip package.
- Add `coverage-badge ^1.1.2` to poetry dev dependencies so the version is locked in `poetry.lock`. The badge step becomes `poetry run coverage-badge -o report/coverage.svg`.
- Pin `setuptools <82` in the dev group: `coverage-badge` imports `pkg_resources` at startup, which was removed in setuptools 82, and its own metadata puts no upper bound on setuptools.

## Verification

- No `tj-actions` reference remains in `.github/` (grep clean).
- Ran the workflow steps locally: pytest with coverage, then `poetry run coverage-badge -o report/coverage.svg` produces a valid SVG.
- Full test suite passes: 509 passed, 9 skipped, 1 xfailed.
- The rest of the workflow (report dir, gh-pages publish, README badge URL) is unchanged, so https://normal-oj.github.io/Back-End/coverage.svg keeps updating after merge.